### PR TITLE
Adding the ability to show data with inner objects collapsed initially.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,14 @@
     //var data = {"hey": "guy","anumber": 243,"anobject": {"whoa": "nuts","anarray": [1,2,"thr<h1>ee"], "more":"stuff"},"awesome": true,"bogus": false,"meaning": null, "japanese":"明日がある。", "link": "http://jsonview.com", "notLink": "http://jsonview.com is great"};
     $(function() {
       $("#data").JSONView(data);
+      $("#data-collapsed").JSONView(data, {collapsed: true});
     });
   </script>
 </head>
 <body>
+  <h2>Data</h2>
   <div id="data"></div>
+  <h2>Data Collapsed</h2>
+  <div id="data-collapsed"></div>
 </body>
 </html>

--- a/jquery.jsonview.js
+++ b/jquery.jsonview.js
@@ -1,4 +1,7 @@
 (function($) {
+
+  var opts;
+
   // JSONFormatter json->HTML prototype straight from Firefox JSONView
   // For reference: http://code.google.com/p/jsonview
   function JSONFormatter() {
@@ -104,7 +107,9 @@
     }
   };
 
-  $.fn.JSONView = function(jsonObj) {
+  $.fn.JSONView = function(jsonObj, options) {
+
+    opts = options || {};
 
     function collapse(evt) {
       var collapser = evt.target;
@@ -158,6 +163,12 @@
     var items = $(this)[0].getElementsByClassName('collapsible');
     for( var i = 0; i < items.length; i++) {
       addCollapser(items[i].parentNode);
+    }
+
+    if(opts.collapsed) {
+      $(this).find('li ul.collapsible').each(function(index, el){
+        $(el).siblings().first().trigger('click');
+      });
     }
   };
 


### PR DESCRIPTION
This little plugin saved me the time of having to write my own, but I need to show larger data objects in a collapsed-ish state initially. So I threw this together to handle collapsing the inner objects if needed. I could make it a little more elegant and collapse the whole thing, but this seems to work for me right now. So I figured I'd PR it in case someone else may need it.

I updated the demo page to show the difference in the two states.
