### PR TITLE
Don't Accidentally Define `module.exports`

### DIFF
--- a/dist/jquery.jsonview.js
+++ b/dist/jquery.jsonview.js
@@ -140,7 +140,9 @@ Licensed under the MIT License.
     return JSONFormatter;
 
   })();
-  (typeof module !== "undefined" && module !== null) && (module.exports = JSONFormatter);
+  if ((module && module.exports) != null) {
+    module.exports = JSONFormatter;
+  }
   Collapser = (function() {
     function Collapser() {}
 


### PR DESCRIPTION
The existing code was only checking that `module` was defined on the
global namespace; however, that does not necessarily mean that this
module is the one used for exporting.

In our codebase, the global `module` actually refers to `angular.module`.
This means that if we import jQuery JSONView after Angular, `JSONFormatter`
will be attached to the `angular.module` object. This on its own is not
really an issue, though probably not an intentional side-effect; however,
if we then import any other module which properly checks for `module.exports`
in addition to just `module` in the global namespace, that module will
also think that `module.exports` should be used instead of the global namespace
for its own module definition. This has the unexpected side-effect of removing
said variable from the global namespace, because it thought it was being
exported (and therefore does not need to export itself as a global var).

Instead, `module.exports` should be checked in addition to just `module`.

Also, I replaced the typeof `x === 'undefined' && x !== null` pattern with
the shorter `x != null` pattern. I noticed that a few other lines were also
using the single-equals null shorthand in this file, so I'm assuming this
is OK, but if you have a preferred style to use here, I'm happy to oblige.